### PR TITLE
Support version --output flag

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/deislabs/porter"
-  version = "v0.13.0-beta.1"
+  version = "v0.17.0-beta.1"
 
 [prune]
   non-go = true

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ structure of this project matches closely with existing Porter [Mixins](https://
    modules, you may chose to clone it outside of the GOPATH.
 1. Rename the `cmd/skeletor` and `pkg/skeletor` directories to `cmd/YOURMIXIN` and
    `pkg/YOURMIXIN`.
-1. Rename `pkg/YOURMIXIN/schema/schem`
 1. Find the text `github.com/deislabs/porter-skeletor/pkg/skeletor` in the repository and change it to 
     `github.com/YOURNAME/YOURREPO/pkg/YOURMIXIN`.
 1. Find any remaining `skeletor` text in the repository and replace it with `YOURMIXIN`.
+1. In `pkg/YOURMIXIN/version.go` replace `YOURNAME` with the name you would like displayed as the mixin
+   author. This value is displayed as the author of your mixin when `porter mixins list` is run.
 1. Run `dep ensure`. Check-in `Gopkg.lock` and `vendor`.
 1. Run `make build xbuild test` to try out all the make targets and
    verify that everything executes without failing.

--- a/cmd/skeletor/version.go
+++ b/cmd/skeletor/version.go
@@ -2,15 +2,27 @@ package main
 
 import (
 	"github.com/deislabs/porter-skeletor/pkg/skeletor"
+	"github.com/deislabs/porter/pkg/porter/version"
 	"github.com/spf13/cobra"
 )
 
 func buildVersionCommand(m *skeletor.Mixin) *cobra.Command {
-	return &cobra.Command{
+	opts := version.Options{}
+
+	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print the mixin version",
-		Run: func(cmd *cobra.Command, args []string) {
-			m.PrintVersion()
+		Short: "Print the mixin verison",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return m.PrintVersion(opts)
 		},
 	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.RawFormat, "output", "o", string(version.DefaultVersionFormat),
+		"Specify an output format.  Allowed values: json, plaintext")
+
+	return cmd
 }

--- a/pkg/skeletor/version.go
+++ b/pkg/skeletor/version.go
@@ -1,11 +1,19 @@
 package skeletor
 
 import (
-	"fmt"
-
 	"github.com/deislabs/porter-skeletor/pkg"
+	"github.com/deislabs/porter/pkg/mixin"
+	"github.com/deislabs/porter/pkg/porter/version"
 )
 
-func (m *Mixin) PrintVersion() {
-	fmt.Fprintf(m.Out, "Skeletor mixin %s (%s)\n", pkg.Version, pkg.Commit)
+func (m *Mixin) PrintVersion(opts version.Options) error {
+	metadata := mixin.Metadata{
+		Name: "skeletor",
+		VersionInfo: mixin.VersionInfo{
+			Version: pkg.Version,
+			Commit:  pkg.Commit,
+			Author:  "YOURNAME",
+		},
+	}
+	return version.PrintVersion(m.Context, opts, metadata)
 }

--- a/pkg/skeletor/version_test.go
+++ b/pkg/skeletor/version_test.go
@@ -1,0 +1,54 @@
+package skeletor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deislabs/porter-skeletor/pkg"
+	"github.com/deislabs/porter/pkg/porter/version"
+	"github.com/deislabs/porter/pkg/printer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintVersion(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	m := NewTestMixin(t)
+
+	opts := version.Options{}
+	err := opts.Validate()
+	require.NoError(t, err)
+	m.PrintVersion(opts)
+
+	gotOutput := m.TestContext.GetOutput()
+	wantOutput := "skeletor v1.2.3 (abc123) by YOURNAME"
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
+	}
+}
+
+func TestPrintJsonVersion(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	m := NewTestMixin(t)
+
+	opts := version.Options{}
+	opts.RawFormat = string(printer.FormatJson)
+	err := opts.Validate()
+	require.NoError(t, err)
+	m.PrintVersion(opts)
+
+	gotOutput := m.TestContext.GetOutput()
+	wantOutput := `{
+  "name": "skeletor",
+  "version": "v1.2.3",
+  "commit": "abc123",
+  "author": "YOURNAME"
+}
+`
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Fatalf("invalid output:\nWANT:\t%q\nGOT:\t%q\n", wantOutput, gotOutput)
+	}
+}


### PR DESCRIPTION
During the office hours coding session, Phillip pointed out that skeletor doesn't generate a version command that prints nicely with `porter mixins list`. This adds support for `--output` to the version command so that mixins created with skeletor also print the mixin version and author, just like ours do.