### PR TITLE
Fix schema command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ structure of this project matches closely with existing Porter [Mixins](https://
 1. In `pkg/YOURMIXIN/version.go` replace `YOURNAME` with the name you would like displayed as the mixin
    author. This value is displayed as the author of your mixin when `porter mixins list` is run.
 1. Replace the `YOURNAME` instances in `pkg/YOURMIXIN/version_test.go` with the name used above.
-1. Run `make build xbuild test` to try out all the make targets and
-   verify that everything executes without failing.
+1. Run `make clean build test-unit xbuild-all test-integration` to try out all the make targets and
+   verify that everything executes without failing. You may need to fix a test string or two.
 1. Run `make install` to install your mixin into the Porter home directory. If
    you don't already have Porter installed, [install](https://porter.sh/install) it first.
 1. Now your mixin is installed, you are ready start customizing and iterating on

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,10 @@ steps:
   displayName: 'Cross Compile'
 
 - script: |
+    make test-integration
+  displayName: 'Integration Test'
+
+- script: |
     AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make publish
   displayName: 'Publish'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/tests/schema_integration_test.go
+++ b/tests/schema_integration_test.go
@@ -1,0 +1,35 @@
+// +build integration
+
+package tests
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Add a test that checked that the schema was packed into the binary
+// properly. Requires a make clean xbuild-all first.
+func TestSchema(t *testing.T) {
+	schemaBackup := "../pkg/skeletor/schema/schema.json.bak"
+	schemaPath := "../pkg/skeletor/schema/schema.json"
+
+	defer os.Rename(schemaBackup, schemaPath)
+	err := os.Rename(schemaPath, schemaBackup)
+	require.NoError(t, err, "failed to sabotage the schema.json")
+
+	output := &bytes.Buffer{}
+	cmd := exec.Command("../bin/mixins/skeletor/skeletor", "schema")
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err = cmd.Start()
+	require.NoError(t, err, "failed to start the skeletor schema command")
+
+	err = cmd.Wait()
+	t.Log(output)
+	require.NoError(t, err, "skeletor schema failed")
+}


### PR DESCRIPTION
* We weren't running generate so the binaries that we shipped didn't include the schema.json file in the binary.
* Add a regression test to catch this type of bug from shipping again.
* Make some tweaks to match our solution for schema with the standard.

While working on this I realized that I was using `exec.Command` wrong in some of the other mixins so you'll see me go back and fix the other mixins to match what is here.